### PR TITLE
Fix Install script when it starts from another folder

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -4,8 +4,8 @@ $sPath = "$env:LOCALAPPDATA\kenk-shift-active-hours"
 if (-not (test-path $sPath)) {
     New-Item $sPath -ItemType "directory"
 }
-copy-item ".\kenk-shift-active-hours.ps1" $sPath
-copy-item ".\Hidden.vbs" $sPath
+copy-item "$PSScriptRoot\kenk-shift-active-hours.ps1" $sPath
+copy-item "$PSScriptRoot\Hidden.vbs" $sPath
 $sCMDFileContent = ('powershell.exe -file "' + "$sPath\kenk-shift-active-hours.ps1" +'"')
 [IO.File]::WriteAllLines("$sPath\run-hidden.cmd", $sCMDFileContent)
 


### PR DESCRIPTION
If install.ps1 is started by right click -> "Start with Powershell" being in another folder then files kenk-shift-active-hours.ps1 and Hidden.vbs fail to copy.